### PR TITLE
PZ-146 | Adding empty directory in empty directory (zip, tar formats)

### DIFF
--- a/src/main/java/com/ntak/pearlzip/archive/zip4j/pub/Zip4jArchiveReadService.java
+++ b/src/main/java/com/ntak/pearlzip/archive/zip4j/pub/Zip4jArchiveReadService.java
@@ -114,7 +114,7 @@ public class Zip4jArchiveReadService implements ArchiveReadService  {
 
             // Handle directory creation
             HashSet<FileInfo> setFiles =
-                    new HashSet<>(files.stream().filter(f -> !f.isFolder()).collect(Collectors.toList()));
+                    new HashSet<>(files.stream().filter(f -> !f.isFolder() && files.stream().noneMatch(g -> g.getFileName().contains(f.getFileName()) && g.getLevel() > f.getLevel())).collect(Collectors.toList()));
             for (FileInfo file : files) {
                 final int level = file.getLevel();
                 Path parent = Paths.get(file.getFileName());
@@ -123,6 +123,29 @@ public class Zip4jArchiveReadService implements ArchiveReadService  {
                     final FileInfo fileInfo = new FileInfo(setFiles.size(),
                                                            level - j,
                                                            parent.toString(),
+                                                           -1,
+                                                           0,
+                                                           0,
+                                                           null,
+                                                           null,
+                                                           null,
+                                                           null,
+                                                           null,
+                                                           0,
+                                                           null,
+                                                           true,
+                                                           false,
+                                                           Collections.singletonMap(
+                                                                   ConfigurationConstants.KEY_ICON_REF,
+                                                                   System.getProperty(
+                                                                           CNS_NTAK_PEARL_ZIP_ICON_FOLDER, "")));
+                    setFiles.add(fileInfo);
+                }
+
+                if (file.isFolder()) {
+                    final FileInfo fileInfo = new FileInfo(setFiles.size(),
+                                                           level,
+                                                           file.getFileName(),
                                                            -1,
                                                            0,
                                                            0,

--- a/src/main/java/com/ntak/pearlzip/archive/zip4j/pub/Zip4jFileHeaderTransform.java
+++ b/src/main/java/com/ntak/pearlzip/archive/zip4j/pub/Zip4jFileHeaderTransform.java
@@ -51,6 +51,11 @@ public class Zip4jFileHeaderTransform implements TransformEntry<FileHeader> {
             rawSize = header.getUncompressedSize();
         }
 
+        // Removal of postfix slash
+        if (fileName.endsWith("/") && isFolder) {
+            fileName = fileName.substring(0,fileName.length()-1);
+        }
+
         FileInfo fileInfo = new FileInfo(index.getAndIncrement(), level, fileName, hash, packedSize, rawSize, lastModifiedTime,
                                          lastModifiedTime, lastModifiedTime, "", "", attributes,
                                          comment, isFolder, isEncrypted, Collections.emptyMap());


### PR DESCRIPTION
+ Including empty directories to file set that need traversing upon listing files so that they are in scope to be displayed on the UI
+ Included the addition of empty folders into the archive
+ Delete checks now checks both prefix and depth to ensure no unexpected side effects when deleting files
+ Updated transform logic to handle postfix slash issue on folder

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>