### PR TITLE
PZ-198 | Zip4J Delete (and consequently move) functionality clearing parent folder contents when in nested directory

### DIFF
--- a/src/main/java/com/ntak/pearlzip/archive/zip4j/pub/Zip4jArchiveReadService.java
+++ b/src/main/java/com/ntak/pearlzip/archive/zip4j/pub/Zip4jArchiveReadService.java
@@ -81,7 +81,7 @@ public class Zip4jArchiveReadService implements ArchiveReadService  {
             }
 
             archiveInfo.setCompressionLevel(Integer.parseInt(CURRENT_SETTINGS.getProperty(CNS_DEFAULT_COMPRESSION_LEVEL, "9")));
-        } catch (ZipException e) {
+        } catch (Exception e) {
             // LOG: Issue generating metadata for archive %s
             LOGGER.error(resolveTextKey(LOG_ARCHIVE_Z4J_ISSUE_GENERATING_METADATA, archivePath));
             archiveInfo = ArchiveService.generateDefaultArchiveInfo(archivePath);
@@ -171,7 +171,7 @@ public class Zip4jArchiveReadService implements ArchiveReadService  {
             }
 
             return new ArrayList<>(setFiles);
-        } catch (ZipException e) {
+        } catch (Exception e) {
             // LOG: Issue listing entries from zip archive.\nException thrown: %s\nException message: %s\nStack
             // trace:\n%s
             // TITLE: Issue listing entries from archive
@@ -217,7 +217,7 @@ public class Zip4jArchiveReadService implements ArchiveReadService  {
                 archive.extractFile(header, parent.toString(), Paths.get(fileInfo.getFileName()).getFileName().toString());
                 return monitor.getResult().equals(ProgressMonitor.Result.SUCCESS);
             }
-        } catch(ZipException e) {
+        } catch(Exception e) {
             // LOG: Issue extracting from zip archive.\nException thrown: %s\nException message: %s\nStack trace:\n%s
             // TITLE: Issue extracting archive
             // HEADER: The archive %s could not be extracted

--- a/src/main/java/com/ntak/pearlzip/archive/zip4j/pub/Zip4jArchiveWriteService.java
+++ b/src/main/java/com/ntak/pearlzip/archive/zip4j/pub/Zip4jArchiveWriteService.java
@@ -97,7 +97,7 @@ public class Zip4jArchiveWriteService implements ArchiveWriteService {
                 // Adding subsequent archive files, if any...
                 addFile(sessionId, archiveInfo, files);
             }
-        } catch(IOException e) {
+        } catch(Exception e) {
             // LOG: Issue creating zip archive.\nException thrown: %s\nException message: %s\nStack trace:\n%s
             // TITLE: Issue creating archive
             // HEADER: The archive %s could not be created
@@ -155,7 +155,7 @@ public class Zip4jArchiveWriteService implements ArchiveWriteService {
                             }).collect(Collectors.toList()));
 
             return true;
-        } catch(ZipException e) {
+        } catch(Exception e) {
             // LOG: Issue adding to zip archive.\nException thrown: %s\nException message: %s\nStack trace:\n%s
             // TITLE: Issue adding to archive
             // HEADER: An entry could not be added to archive %s
@@ -239,7 +239,11 @@ public class Zip4jArchiveWriteService implements ArchiveWriteService {
 
                 // Keep immediate parent if last file is deleted...
                 Path parent = Paths.get(file.getFileName()).getParent();
-                if (Objects.nonNull(parent)) {
+
+                if (Objects.nonNull(parent) && archive.getFileHeaders()
+                                                      .stream()
+                                                      .noneMatch(f -> f.getFileName()
+                                                                       .startsWith(parent.toString()))) {
                     try {
                         // Create temp directory structure to persist...
                         Path tempDirectory = Files.createTempDirectory("pz");


### PR DESCRIPTION
+ Updated conditions to cater for last file in folder case (which ensures directory entry remains)
+ Issues will be reported on all exceptions

Signed-off-by: Aashutos Kakshepati <aashutos_kakshepati@hotmail.com>